### PR TITLE
Fixing PR#18 conflict bug

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -28,7 +28,6 @@
 defined("MOODLE_INTERNAL") || die();
 
 require_once(__DIR__ . "/lib.php");
-require_once(__DIR__ . "/settingslib.php");
 require_once(__DIR__ . "/locallib.php");
 
 // Ensure that default_language can only be changed into a valid language!


### PR DESCRIPTION
During the merge of pull request 18, the line "require_once(__DIR__ . "/settingslib.php");" was reintroduced, which had previously been deleted. This is hereby fixed.