### PR TITLE
dev401 I norename

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -653,16 +653,11 @@ function block_coursefeedback_get_editerrors($feedbackid) {
 function block_coursefeedback_set_active($feedbackid) {
     global $DB;
     if ($feedbackid == 0 || $DB->record_exists("block_coursefeedback", array("id" => $feedbackid))) {
-
         $oldfeedbackid = get_config("block_coursefeedback", "active_feedback");
         if (block_coursefeedback_answers_exist($oldfeedbackid)) {
-            // If answers for the last FB exist -> rename it and delete the saved userids.
+            // If answers for the last FB exist -> delete the saved userids.
             // It will not be possible to reactivate a FB for which answers exist
-            $oldfeedback = $DB->get_record("block_coursefeedback", array("id" => $oldfeedbackid));
-            $newname = $oldfeedback->name . "_stop" . date('Ymd', time());
-
             $DB->delete_records("block_coursefeedback_uidansw", array("coursefeedbackid" => $oldfeedbackid));
-            $DB->set_field("block_coursefeedback", "name", $newname, array("id" => $oldfeedbackid));
         }
         set_config("active_feedback", $feedbackid, "block_coursefeedback");
         return true;

--- a/lib.php
+++ b/lib.php
@@ -647,6 +647,9 @@ function block_coursefeedback_get_editerrors($feedbackid) {
 }
 
 /**
+ * Sets the feedback with the given ID as active by updating the configuration setting.
+ * Deletes the user-ID answers of the previously active feedback if they exist.
+ *
  * @param int $feedbackid
  * @return bool - false, if specified feedback doesn"t exists
  */


### PR DESCRIPTION
Als man im Plugin noch automatisierte Zeiträume einstellen konnte und sich eine Umfrage dadurch z.B. jedes Semster wiederholte, hatte ich beim (automatisierten) Deaktivieren einer Umfrage eingebaut, dass dem Namen der Umfrage ein Postfix angehängt wurde.
Die automatisierte Umbenennung hat Martin nicht gefallen und mittlerweile können Umfragen auch nur noch manuell geschaltet und beendet werden. Damit ist diese auch nicht mehr notwendig und wird in diesem PR entfernt.

Die Änderungen betreffen lediglich eine Funktion welche dafür verantwortlich ist eine Umfrage anhand ihrer ID aktiv zu schalten.
