### PR TITLE
dev401_II Simplified and restructured csv downloads for fb-course results

### DIFF
--- a/classes/form/f_ranking_form.php
+++ b/classes/form/f_ranking_form.php
@@ -83,7 +83,8 @@ class f_ranking_form extends moodleform {
         if ($feedback === '' || $feedback === null) {
             return;
         }
-        $choices = block_coursefeedback_get_questions($feedback);
+        $currentlang = [current_language()];
+        $choices = block_coursefeedback_get_questions_by_language($feedback, $currentlang);
         $q = $mform->getElement('question');
         $q->loadArray($choices);;
     }

--- a/classes/form/f_ranking_form.php
+++ b/classes/form/f_ranking_form.php
@@ -70,23 +70,4 @@ class f_ranking_form extends moodleform {
         }
         return $options;
     }
-
-    public function definition_after_data() {
-        parent::definition_after_data();
-        $mform = $this->_form;
-
-        $feedback = $mform->getElementValue('feedback');
-        if (is_null($feedback)) {
-            return;
-        }
-        $feedback = $feedback[0];
-        if ($feedback === '' || $feedback === null) {
-            return;
-        }
-        $currentlang = [current_language()];
-        $choices = block_coursefeedback_get_questions_by_language($feedback, $currentlang);
-        $q = $mform->getElement('question');
-        $q->loadArray($choices);;
-    }
 }
-

--- a/exportlib.php
+++ b/exportlib.php
@@ -30,134 +30,57 @@ defined("MOODLE_INTERNAL") || die();
 require_once($CFG->dirroot . "/blocks/coursefeedback/lib.php");
 require_once($CFG->libdir . '/csvlib.class.php');
 
-class feedbackexport {
-    protected $course = 0;
-    protected $feedback = 0;
-    protected $filetypes = array("csv");
-    private $content = "";
-    private $format;
-
-    public function __construct($course = 0, $feedback = 0, $seperator = "\t") {
-        global $DB;
-
-        if ($DB->record_exists("course", array("id" => $course))) {
-            $this->course = $course;
-            $this->feedback = $feedback;
-        } else {
-            print_error("courseidnotfound", "error");
-            exit(0);
-        }
-    }
-
-    public function get_filetypes() {
-        return $this->filetypes;
-    }
-
-    public function init_format($format) {
-        if (in_array($format, $this->get_filetypes())) {
-            $exportformatclass = "exportformat_" . $format;
-            $this->format = new $exportformatclass();
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    public function create_file($lang) {
-        global $CFG, $DB;
-
-        if (!isset($this->format)) {
-            print_error("format not initialized", "block_coursefeedback");
-        } else {
-            $answers = block_coursefeedback_get_answers($this->course, $this->feedback);
-            $this->reset();
-            $this->content = $this->format->build($answers, $lang);
-        }
-    }
-
-    public function get_content() {
-        return $this->content;
-    }
-
-    public function reset() {
-        $this->content = "";
-    }
-}
 
 /**
- * @author Jan Eberhardt
- * Generell format class. Doesn"t contain very much so far, but should provide basics.
+ * Export feedback data for a course.
+ *
+ * @package block
+ * @subpackage coursefeedback
+ * @copyright innoCampus, TU Berlin
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-abstract class exportformat {
-    private $type = "unknown";
+class feedback_exporter {
+    protected $csvexportwriter;
 
-    public final function get_type() {
-        return $this->type;
-    }
-
-    public abstract function build($arg1);
-}
-
-/**
- * @author Jan Eberhardt
- * CSV export class
- */
-class exportformat_csv extends exportformat {
-    public $seperator;
-    public $newline;
-    public $quotes;
-
-    /**
-     * Set CSV options.
-     *
-     * TODO Choosable values.
-     */
     public function __construct() {
-        $this->type = "csv";
-        $this->seperator = ";";
-        $this->newline = "\n";
-        $this->quotes = "\"";
+        $this->csvexportwriter = new csv_export_writer();
     }
 
-    /**
-     * (non-PHPdoc)
-     * @see exportformat::build()
-     */
-    public function build($answers, $lang = null) {
+    public function create_file($courseid, $feedbackid) {
         global $DB;
-        $config = get_config("block_coursefeedback");
-        $content = $this->quote(get_string("download_thead_questions", "block_coursefeedback"))
-            . $this->seperator
-            . $this->quote(get_string("table_html_nochoice", "block_coursefeedback"));
-        for ($i = 1; $i < 7; $i++) {
-            $content .= $this->seperator . $i;
-        }
-        $content .= $this->newline;
+        $this->csvexportwriter->set_filename(get_string("download_html_filename", "block_coursefeedback")
+            . date("_Y-m-d-H-i"));
+        $headrow = [
+            get_string("download_thead_questions", "block_coursefeedback"),
+            get_string('notif_emoji_super', 'block_coursefeedback'),
+            get_string('notif_emoji_good', 'block_coursefeedback'),
+            get_string('notif_emoji_ok', 'block_coursefeedback'),
+            get_string('notif_emoji_neutral', 'block_coursefeedback'),
+            get_string('notif_emoji_bad', 'block_coursefeedback'),
+            get_string('notif_emoji_superbad', 'block_coursefeedback'),
+            get_string('table_html_average', 'block_coursefeedback'),
+            get_string('table_html_votes', 'block_coursefeedback'),
+            get_string('table_html_nochoice', 'block_coursefeedback'),
+        ];
+        $this->csvexportwriter->add_data($headrow);
 
-        $lang = block_coursefeedback_find_language($lang);
+        // Get the counted answers for each question and each answer possibility
+        $qanswercounts = block_coursefeedback_get_qanswercounts($courseid, $feedbackid);
 
-        foreach ($answers as $questionid => $values) {
-            $conditions = array("coursefeedbackid" => $config->active_feedback,
-                    "language" => $lang,
-                    "questionid" => $questionid);
-            if ($question = $DB->get_field("block_coursefeedback_questns", "question", $conditions)) {
-                $question = $this->quote(format_text(trim($question, " \""), FORMAT_PLAIN));
-                $content .= $question . $this->seperator . join($this->seperator, $values) . $this->newline;
+        $questions = block_coursefeedback_get_questions_by_language($feedbackid, [current_language()]);
+        foreach ($questions as $question) {
+            // Put questionstring in front of $answerdata and add the data to the csv file
+            if ($qanswercounts[$question->questionid]) {
+                $answersdata = $qanswercounts[$question->questionid];
+                array_unshift($answersdata, $question->question);
+                $this->csvexportwriter->add_data($answersdata);
             }
         }
 
-        return $content;
+        // Start the download
+        $this->csvexportwriter->download_file();
     }
 
-    /**
-     * Quotes a field value.
-     *
-     * @param string $str
-     * @return string
-     */
-    private function quote($str) {
-        return $this->quotes . $str . $this->quotes;
-    }
 }
 
 /**

--- a/lang/de/block_coursefeedback.php
+++ b/lang/de/block_coursefeedback.php
@@ -76,7 +76,7 @@ $string['page_html_courserating'] = 'Kursbewertung';
 /* Tables */
 $string['table_header_languages'] = 'Verf&uuml;gbare Sprachen';
 $string['table_header_questions'] = 'Fragen';
-$string['table_html_votes'] = 'Anzahl der Stimmen:';
+$string['table_html_votes'] = 'Anzahl der Stimmen';
 $string['table_html_average'] = 'Durchschnitt';
 $string['table_html_nochoice'] = 'Enthaltungen';
 $string['table_html_nofeedback'] = 'Keine Umfrage';
@@ -138,6 +138,7 @@ $string['perm_html_wasactive'] = 'Die Umfrage war bereits aktive, erneutes aktiv
 $string['eventviewed'] = 'Ergebnisse angezeigt';
 
 /* Exceptions */
+$string['except_invalid_courseid'] = 'Ungültige Kurs-ID';
 $string['except_no_question'] = 'Umfrage oder Frage existiert nicht';
 $string['except_answer_exist'] = 'Antwort für diese Frage existiert bereits';
 $string['except_not_active'] = 'Die Umfrage ist nicht aktiv im Moment';

--- a/lang/en/block_coursefeedback.php
+++ b/lang/en/block_coursefeedback.php
@@ -76,7 +76,7 @@ $string['page_html_courserating'] = 'Course rating';
 /* Tables */
 $string['table_header_languages'] = 'Available languages';
 $string['table_header_questions'] = 'Questions';
-$string['table_html_votes'] = ' Number of votes : ';
+$string['table_html_votes'] = ' Number of votes';
 $string['table_html_average'] = 'Average';
 $string['table_html_nochoice'] = 'Abstentions';
 $string['table_html_nofeedback'] = 'No survey';
@@ -138,6 +138,7 @@ $string['perm_html_wasactive'] = 'The feedback was active before -> reactivation
 $string['eventviewed'] = 'Results viewed';
 
 /* Exceptions */
+$string['except_invalid_courseid'] = 'Invalid course id';
 $string['except_no_question'] = 'Feedback or question does not exist';
 $string['except_answer_exist'] = 'Answer for this question already exist';
 $string['except_not_active'] = 'Given feedback not active at the monent';

--- a/lib.php
+++ b/lib.php
@@ -565,7 +565,7 @@ function block_coursefeedback_get_qanswercounts($course, $feedbackid) {
  *
  * @param int $coursfeedback_id - Feedback Id of questions to be shown
  * @param array $languages - array of language codes (sorted by priority)
- * @return array - Returns an array of strings (should be questions)
+ * @return array - array of question objects
  */
 function block_coursefeedback_get_questions_by_language($feedbackid,
         $languages,

--- a/lib.php
+++ b/lib.php
@@ -525,11 +525,11 @@ function block_coursefeedback_get_qanswercounts($course, $feedbackid) {
             $questionid = $question->questionid;
             $params["qid"] = $questionid;
             $sql = "SELECT answer,COUNT(*) AS count
-                    FROM {block_coursefeedback_answers}
-                    WHERE coursefeedbackid = :fid 
-                        AND questionid = :qid 
-                        AND course = :course
-                    GROUP BY answer";
+                      FROM {block_coursefeedback_answers}
+                     WHERE coursefeedbackid = :fid 
+                           AND questionid = :qid 
+                           AND course = :course
+                  GROUP BY answer";
 
             // Create array for the question and fill in zeros for each answeroption
             $answers[$questionid] = array_fill(1, 6, 0);

--- a/lib.php
+++ b/lib.php
@@ -494,14 +494,19 @@ function block_coursefeedback_get_feedbackname($feedbackid = null) {
 
     return htmlentities($name);
 }
-
 /**
+ * This function gets the amount of votes for each answeroption (1-6) and each question.
+ * It calculates the amount of counted choices, the amount of abstentions and the average rating for each question
+ *
  * @param int $courseid
  * @param string $sort
- * @return array - 2-dimensional array of answers, ordered by question id
+ * @return array - 2-dimensional array of answers, ordered by question id as follows:
+ * [ "<questionid>" =>
+ *      [ "1" => <answercount>, ..., "6" => <answercount>, "average" =>..., "choicessum" =>..., "abstentions" => ... ]]
+ * @throws moodle_exception
  */
-function block_coursefeedback_get_answers($course, $feedbackid, $sort = "questionid") {
-    global $DB, $CFG, $USER;
+function block_coursefeedback_get_qanswercounts($course, $feedbackid) {
+    global $DB;
     $config = get_config("block_coursefeedback");
     $answers = array();
     $course = clean_param($course, PARAM_INT);
@@ -509,39 +514,58 @@ function block_coursefeedback_get_answers($course, $feedbackid, $sort = "questio
     if ($course <= 0) {
         throw new moodle_exception("invalidcourseid");
     }
-
-    $questions = block_coursefeedback_get_questions($feedbackid, $config->default_language);
+    // Get all the questions of the feedback
+    $questions = block_coursefeedback_get_questions_by_language($feedbackid, [current_language()]);
     $params = array("fid" => $feedbackid, "course" => $course);
     if (!empty($questions)) {
-        $count = count($questions);
-        foreach (array_keys($questions) as $question) {
-            $params["qid"] = $question;
+        // For each question and each answerpossibility, count the amount of the given answers
+        foreach ($questions as $question) {
+            $choicessum = 0;
+            $avsum = 0;
+            $questionid = $question->questionid;
+            $params["qid"] = $questionid;
             $sql = "SELECT answer,COUNT(*) AS count
-                      FROM {block_coursefeedback_answers}
-                     WHERE coursefeedbackid = :fid 
-                           AND questionid = :qid 
-                           AND course = :course
-                  GROUP BY answer";
+                    FROM {block_coursefeedback_answers}
+                    WHERE coursefeedbackid = :fid 
+                        AND questionid = :qid 
+                        AND course = :course
+                    GROUP BY answer";
 
+            // Create array for the question and fill in zeros for each answeroption
+            $answers[$questionid] = array_fill(1, 6, 0);
+
+            $answers[$questionid]['average'] = "x";
+            $answers[$questionid]['choicessum'] = 0;
+            $answers[$questionid]['abstentions'] = 0;
+            // If answers for question exist, replace the zero at the right index and calculate average and choicessum
             if ($results = $DB->get_records_sql($sql, $params)) {
-                $answers[$question] = array();
                 foreach ($results as $answer) {
-                    $answers[$question][$answer->answer] = $answer->count;
+                    // Abstentions are not counted for average and choicessum
+                    if ($answer->answer == 0) {
+                        $answers[$questionid]['abstentions'] = $answer->count;
+                    } else {
+                        $answers[$questionid][$answer->answer] = $answer->count;
+                        $choicessum += $answer->count;
+                        $avsum += $answer->answer * $answer->count;
+                    }
                 }
-                block_coursefeedback_array_fill_spaces($answers[$question], 0, 8, 0);
-            } else {
-                $answers[$question] = array_fill(0, 8, 0);
+                // Calculate choices and average for each question
+                $average = $choicessum > 0 ? ($avsum / $choicessum) : 0;
+                $answers[$questionid]['average'] = $average;
+                $answers[$questionid]['choicessum'] = $choicessum;
             }
         }
-        block_coursefeedback_array_fill_spaces($answers, 1, $count, array_fill(0, 8, 0));
     }
     return $answers;
 }
 
+
 /**
+ * Returns an array of questions in a well defined lang for the given feedback
+ *
  * @param int $coursfeedback_id - Feedback Id of questions to be shown
  * @param array $languages - array of language codes (sorted by priority)
- * @return array - Returns an array of strings (should be questions) or false, if table is empty
+ * @return array - Returns an array of strings (should be questions)
  */
 function block_coursefeedback_get_questions_by_language($feedbackid,
         $languages,
@@ -560,7 +584,8 @@ function block_coursefeedback_get_questions_by_language($feedbackid,
     }
 
     $fblanguages = block_coursefeedback_get_combined_languages($feedbackid);
-    $questions = false;
+    $questions = [];
+
     if ($fblanguages && $language = current(array_intersect($languages, $fblanguages))) {
         $questions = $DB->get_records("block_coursefeedback_questns",
             array("coursefeedbackid" => $feedbackid, "language" => $language),
@@ -590,37 +615,6 @@ function block_coursefeedback_get_question_ids($feedbackid = COURSEFEEDBACK_DEFA
     $select = "coursefeedbackid = ? GROUP BY questionid ORDER BY questionid";
 
     return $DB->get_fieldset_select("block_coursefeedback_questns", "questionid", $select, array($feedbackid));
-}
-
-/**
- * @param int|COURSEFEEDBACK_DEFAULT $feedbackid (default is currently activated feedback)
- * @param string|COURSEFEEDBACK_DEFAULT $language - Language code (default is currently default language)
- * @return array - Returns an array of questions or false
- */
-function block_coursefeedback_get_questions($feedbackid = COURSEFEEDBACK_DEFAULT, $language = COURSEFEEDBACK_DEFAULT) {
-    global $DB;
-
-    $res = array();
-    $params = array();
-
-    if ($feedbackid === COURSEFEEDBACK_DEFAULT) {
-        $feedbackid = get_config("block_coursefeedback", "active_feedback");
-    }
-
-    if ($language === COURSEFEEDBACK_DEFAULT) {
-        $language = get_config("block_coursefeedback", "default_language");
-    }
-
-    $params["coursefeedbackid"] = intval($feedbackid);
-    $params["language"] = preg_replace("/[^a-z]/", "", $language);
-
-    if ($records = $DB->get_records("block_coursefeedback_questns", $params, "questionid ASC", "questionid,question")) {
-        foreach ($records as $record) {
-            $res[$record->questionid] = $record->question;
-        }
-    }
-
-    return $res;
 }
 
 /**
@@ -867,30 +861,6 @@ function block_coursefeedback_get_language($langcode) {
 }
 
 /**
- * Searchs for the proper language code for evaluation.
- *
- * @return String - Language code
- */
-function block_coursefeedback_find_language($lang = null) {
-    global $USER, $COURSE, $DB;
-
-    $config = get_config("block_coursefeedback");
-    $langs = block_coursefeedback_get_combined_languages($config->active_feedback);
-
-    if ($lang !== null && in_array($lang, $langs)) {
-        return $lang;
-    } else if (in_array($USER->lang, $langs)) {
-        return $USER->lang;
-    } else if (in_array($COURSE->lang, $langs)) {
-        return $COURSE->lang;
-    } else if (in_array($config->default_language)) {
-        return $config->default_language;
-    } else {
-        return null;
-    } // No questions available.
-}
-
-/**
  * Checks if there are questions to display for coursefeedback
  *
  * @param string $feedbackid
@@ -930,16 +900,15 @@ function block_coursefeedback_answers_exist($feedbackid) {
 function block_coursefeedback_validate($feedbackid, $returnerrors = false) {
     $notifications = array();
     $feedbackid = intval($feedbackid);
+    $defaultlang[] = get_config("block_coursefeedback", "default_language");
     if ($feedbackid > 0) {
         $langs = block_coursefeedback_get_combined_languages($feedbackid);
         if (empty($langs)) {
             $notifications[] = get_string("page_html_norelations", "block_coursefeedback");
-        }
-        $count = block_coursefeedback_get_questionid($feedbackid) - 1;
-        if ($count !== count(block_coursefeedback_get_questions($feedbackid))) {
+        } elseif (!array_intersect($langs, $defaultlang)) {
             $notifications[] = get_string("page_html_servedefaultlang",
                 "block_coursefeedback",
-                get_config("block_coursefeedback", "default_language"));
+                $defaultlang);
         }
     }
     if ($returnerrors) {
@@ -948,7 +917,6 @@ function block_coursefeedback_validate($feedbackid, $returnerrors = false) {
         return empty($notifications);
     }
 }
-
 function format($string) {
     return format_text(stripslashes($string), FORMAT_PLAIN);
 }
@@ -979,7 +947,7 @@ function block_coursefeedback_adminurl($mode, $action, $fid = null, array $other
 function block_coursefeedback_get_open_question() {
     global $DB, $COURSE, $USER;
     $config = get_config("block_coursefeedback");
-    $currentlang = current_language();
+    $currentlang[] = current_language();
     // Check if FB is active just in case
     if (isset($config->active_feedback) && $config->active_feedback != 0) {
         $questions = block_coursefeedback_get_questions_by_language($config->active_feedback, $currentlang);

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@
 
 defined("MOODLE_INTERNAL") || die();
 
-$plugin->version = 2023060712;
+$plugin->version = 2023082901;
 $plugin->requires = 2014051200;
 $plugin->maturity = MATURITY_BETA;
 $plugin->release = "3.1.0 (Build: 2023060600)";


### PR DESCRIPTION
Ich habe hauptsächlich die Logik des csv-Downloads von Feedbackergebnissen eines Kurses vereinfacht.
Die Ergebnisse können von Trainer:innen eines Kurses eingesehen werden indem auf den Link (Name des Feedbacks) im Block geklickt wird -> ".../view.php?course=10&feedback=3".

Auf view.php werden die Ergebnisse dargestellt und auch als CSV-Download angeboten.
Ich hab den Downloadvorgang über den "csv_export_writer" realisiert. (exportlib.php)
Der Download wird jetzt einfach über "$export->create_file($courseid, $feedbackid);" in der view.php ausgelöst.

Im Zuge der Änderungen habe ich die Berechnungen der Durchschnitte sowie der Gesamtanzahl der Votes in die Funktion "block_coursefeedback_get_qanswercounts()" ausgelagert.
Generell gehört die ganze "view.php" überarbeitet aber nicht an dieser Stelle. 

 Außerdem habe ich folgende Funktionen in der lib.php geändert:

- "block_coursefeedback_get_answers()" wurde zu  "block_coursefeedback_get_qanswercounts()" und berechnet jetzt die Anzahl der jeweiligen gegebenen Antworten, sowie des Durchschnitts, der Gesamtanzahl der Votes  und der Enthaltungen (Enthaltungen können eigtl. nicht mehr vorkommen. Früher konnten sich TNs enthalten und damit die Anzeige alter Umfrageergebnisse weiterhin gewährleistet ist, bleibt dieser Punkt erstmal drin).
- "block_coursefeedback_get_questions_by_language()" : Diese Funktion übernimmt jetzt auch die Arbeit der Funktion "block_coursefeedback_get_questions" welche dadurch komplett entfernt werden konnte.
- "block_coursefeedback_find_language" konnte dadurch auch komplett entfernt werden.
- "block_coursefeedback_validate" konnte vereinfacht werden.
- "block_coursefeedback_get_open_question" wurde gefixt.

Strings wurden geringfügig angepasst, und eine deprecated function (error() in view.php) wurde durch eine Moodle-Exception ersetzt.

Um den PR Umfang so gering wie möglich zu halten habe ich die geänderten Funktionen erstmal nicht in die locallib verschoben damit Sie nicht global erreichbar sind. Das mach ich dann in einem anderen PR welcher ausschließlich dafür ist.

