### PR TITLE
Fix former unwanted DB changes

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -41,7 +41,7 @@
         <FIELD NAME="course" TYPE="int" LENGTH="20" NOTNULL="true" UNSIGNED="true" SEQUENCE="false" PREVIOUS="id" NEXT="coursefeedbackid"/>
         <FIELD NAME="coursefeedbackid" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="false" PREVIOUS="course" NEXT="questionid"/>
         <FIELD NAME="questionid" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="false" PREVIOUS="coursefeedbackid" NEXT="answer"/>
-        <FIELD NAME="answer" TYPE="int" LENGTH="4" NOTNULL="false" UNSIGNED="true" SEQUENCE="false" PREVIOUS="questionid" NEXT="textanswer"/>
+        <FIELD NAME="answer" TYPE="int" LENGTH="4" NOTNULL="true" UNSIGNED="true" SEQUENCE="false" PREVIOUS="questionid" NEXT="timemodified"/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" DEFAULT="0" PREVIOUS="answer"/>
       </FIELDS>
       <KEYS>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -242,7 +242,7 @@ function xmldb_block_coursefeedback_upgrade($oldversion = 0) {
         // Check if the 'answer' field in the table 'block_coursefeedback_answers' has the correct 'NOTNULL' value.
         $field = new xmldb_field('answer', XMLDB_TYPE_INTEGER, '4', null, XMLDB_NOTNULL, null, null, 'questionid');
         // Drop index temporarily to make field change possible.
-        $index = new xmldb_index('mdl2_bloccouransw_coucouque_ix', XMLDB_INDEX_NOTUNIQUE, ['course', 'coursefeedbackid', 'questionid', 'answer']);
+        $index = new xmldb_index('bloccouransw_coucouque_ix', XMLDB_INDEX_NOTUNIQUE, ['course', 'coursefeedbackid', 'questionid', 'answer']);
         if ($dbman->index_exists($table, $index)) {
             $dbman->drop_index($table, $index);
         }

--- a/version.php
+++ b/version.php
@@ -30,5 +30,5 @@ defined("MOODLE_INTERNAL") || die();
 $plugin->version = 2024015001;
 $plugin->requires = 2014051200;
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = "3.3.0 (Build: 2024012004)";
+$plugin->release = "3.3.1 (Build: 2024015001)";
 $plugin->component = "block_coursefeedback";

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@
 
 defined("MOODLE_INTERNAL") || die();
 
-$plugin->version = 2024015000;
+$plugin->version = 2024015001;
 $plugin->requires = 2014051200;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = "3.3.0 (Build: 2024012004)";


### PR DESCRIPTION

Die Änderung ist fälschlicherweise von einer vorangegangenen Idee mit rein gerutscht Da dachte ich noch ich füge der Tabelle ein "textanswer" Feld hinzu anstelle eine eigene Tabelle zu machen.

Dementsprechend wäre dann teilweise im "answer" Feld "null" möglich gewesen, was jetzt aber nicht benötigt wird und darum auch nicht in upgrade.php abgebildet werden muss.
