### PR TITLE
Fix pagination for essay answers

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -196,9 +196,10 @@ class block_coursefeedback_renderer extends plugin_renderer_base {
         $answerhtml .= html_writer::tag('div', $link);
 
         // Get all textanswers for the given $questionid and add them in a table.
+        $limitfrom = $perpage * $page;
         $answers = $DB->get_records('block_coursefeedback_textans', ['course' => $courseid,
                 'coursefeedbackid' => $feedbackid,
-                'questionid' => $questionid], '', 'id,textanswer', $page, $perpage);
+                'questionid' => $questionid], '', 'id,textanswer', $limitfrom, $perpage);
 
         // Get the $question(text) of the given $questionid
         $question = block_coursefeedback_get_questions_by_language($feedbackid, current_language(),

--- a/version.php
+++ b/version.php
@@ -30,5 +30,5 @@ defined("MOODLE_INTERNAL") || die();
 $plugin->version = 2024015002;
 $plugin->requires = 2014051200;
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = "3.3.2 (Build: 2024015001)";
+$plugin->release = "3.3.2 (Build: 2024015002)";
 $plugin->component = "block_coursefeedback";

--- a/version.php
+++ b/version.php
@@ -27,8 +27,8 @@
 
 defined("MOODLE_INTERNAL") || die();
 
-$plugin->version = 2024015001;
+$plugin->version = 2024015002;
 $plugin->requires = 2014051200;
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = "3.3.1 (Build: 2024015001)";
+$plugin->release = "3.3.2 (Build: 2024015001)";
 $plugin->component = "block_coursefeedback";


### PR DESCRIPTION
Ich habe vergessen die $page Variable in $limitfrom (für get_records(...)) umzurechnen.
Somit werden die Antworten der Essyantworten im Moment nicht richtig paginiert.

Diese PR fixt dieses Problem.