### PR TITLE
Do not show empty essayanswers in the table

### DIFF
--- a/essayanswers.php
+++ b/essayanswers.php
@@ -74,19 +74,17 @@ $baseurl = new moodle_url("/blocks/coursefeedback/essayanswers.php", [
     "perpage" => $perpage]);
 
 // How many non-empty essayanswers for this question?
-$sql = "SELECT COUNT(id) 
-          FROM {block_coursefeedback_textans}
-         WHERE course = :course 
-               AND coursefeedbackid = :coursefeedbackid 
-               AND questionid = :questionid 
-               AND textanswer IS NOT NULL 
-               AND textanswer <> ''";
+$select = "course = :course
+       AND coursefeedbackid = :coursefeedbackid 
+       AND questionid = :questionid 
+       AND textanswer IS NOT NULL 
+       AND textanswer <> ''";
 $params = [
     'course' => $courseid,
     'coursefeedbackid' => $feedbackid,
     'questionid' => $questionid
 ];
-$anscount = $DB->count_records_sql($sql, $params);
+$anscount = $DB->count_records_select('block_coursefeedback_textans', $select, $params);
 
 $PAGE->set_url($baseurl);
 $PAGE->set_context($context);

--- a/essayanswers.php
+++ b/essayanswers.php
@@ -73,12 +73,20 @@ $baseurl = new moodle_url("/blocks/coursefeedback/essayanswers.php", [
     "page" => $page,
     "perpage" => $perpage]);
 
-// How many answers in total for this question?
-$totalcount = $DB->count_records('block_coursefeedback_textans', [
+// How many non-empty essayanswers for this question?
+$sql = "SELECT COUNT(id) 
+          FROM {block_coursefeedback_textans}
+         WHERE course = :course 
+               AND coursefeedbackid = :coursefeedbackid 
+               AND questionid = :questionid 
+               AND textanswer IS NOT NULL 
+               AND textanswer <> ''";
+$params = [
     'course' => $courseid,
     'coursefeedbackid' => $feedbackid,
     'questionid' => $questionid
-]);
+];
+$anscount = $DB->count_records_sql($sql, $params);
 
 $PAGE->set_url($baseurl);
 $PAGE->set_context($context);
@@ -89,12 +97,12 @@ $PAGE->navbar->add(get_string("page_html_viewnavbar", "block_coursefeedback"));
 
 // Render the answers for this question.
 $renderer = $PAGE->get_renderer('block_coursefeedback');
-$essayhtml = $renderer->render_essay_answers($courseid, $feedbackid, $questionid, $totalcount, $page, $perpage);
+$essayhtml = $renderer->render_essay_answers($courseid, $feedbackid, $questionid, $anscount, $page, $perpage);
 
 // Start output.
 echo $OUTPUT->header();
 echo $OUTPUT->heading(get_string("pluginname", "block_coursefeedback") . ": "
     . format_string($feedback->name));
 echo $OUTPUT->box($essayhtml);
-echo $OUTPUT->paging_bar($totalcount, $page, $perpage, $baseurl);
+echo $OUTPUT->paging_bar($anscount, $page, $perpage, $baseurl);
 echo $OUTPUT->footer();

--- a/lang/de/block_coursefeedback.php
+++ b/lang/de/block_coursefeedback.php
@@ -81,7 +81,7 @@ $string['page_html_intronotifications'] = 'Dieses Feedback muss folgende Konditi
 $string['page_html_servedefaultlang'] = 'Alle Fragen sollten in der eingestellte Standardsprache ({$a}) vorhanden sein.';
 $string['page_html_norelations'] = 'Alle Fragen müssen in mindestens einer gemeinsamen Sprache vorhanden sein.';
 $string['page_html_courserating'] = 'Kursbewertung';
-$string['page_html_totalanscountinfo'] = 'Insgesamt {$a->totalcount} Antworten, Sie befinden sich auf Seie {$a->page} von {$a->totalpages}.';
+$string['page_html_totalanscountinfo'] = 'Insgesamt {$a->anscount} nicht leere Antworten, Sie befinden sich auf Seie {$a->page} von {$a->totalpages}.';
 
 /* Tables */
 $string['table_header_languages'] = 'Verf&uuml;gbare Sprachen';
@@ -162,4 +162,5 @@ $string['except_wrong_questiontype'] = 'Ungültiger Antworttyp übermittelt';
 $string['questiontype'] = 'Fragetyp';
 $string['questiontype_schoolgrades'] = 'Schulnoten eins bis sechs';
 $string['questiontype_essay'] = 'Freitext';
+$string['qtype_empty_essayans'] = 'Es gibt insgesamt {$a} leere Freitextantworten.';
 

--- a/lang/de/block_coursefeedback.php
+++ b/lang/de/block_coursefeedback.php
@@ -81,7 +81,7 @@ $string['page_html_intronotifications'] = 'Dieses Feedback muss folgende Konditi
 $string['page_html_servedefaultlang'] = 'Alle Fragen sollten in der eingestellte Standardsprache ({$a}) vorhanden sein.';
 $string['page_html_norelations'] = 'Alle Fragen müssen in mindestens einer gemeinsamen Sprache vorhanden sein.';
 $string['page_html_courserating'] = 'Kursbewertung';
-$string['page_html_totalanscountinfo'] = 'Insgesamt {$a->anscount} nicht leere Antworten, Sie befinden sich auf Seie {$a->page} von {$a->totalpages}.';
+$string['page_html_totalanscountinfo'] = 'Insgesamt {$a->anscount} nicht leere Antworten, Sie befinden sich auf Seite {$a->page} von {$a->totalpages}.';
 
 /* Tables */
 $string['table_header_languages'] = 'Verf&uuml;gbare Sprachen';

--- a/lang/en/block_coursefeedback.php
+++ b/lang/en/block_coursefeedback.php
@@ -81,7 +81,7 @@ $string['page_html_intronotifications'] = 'This feedback has to fullfill the fol
 $string['page_html_servedefaultlang'] = 'All questions should be defined in default language.';
 $string['page_html_norelations'] = 'All questions have to be defined in at least one common language.';
 $string['page_html_courserating'] = 'Course rating';
-$string['page_html_totalanscountinfo'] = '{$a->totalcount} answers in total, you are on page {$a->page} of {$a->totalpages}.';
+$string['page_html_totalanscountinfo'] = '{$a->anscount} non-empty answers in total, you are on page {$a->page} of {$a->totalpages}.';
 
 /* Tables */
 $string['table_header_languages'] = 'Available languages';
@@ -162,4 +162,5 @@ $string['except_wrong_questiontype'] = 'Invalid answertype received';
 $string['questiontype'] = 'Questiontype';
 $string['questiontype_schoolgrades'] = 'Schoolgrades one to six';
 $string['questiontype_essay'] = 'Essay';
+$string['qtype_empty_essayans'] = 'There are a total of {$a} empty essay responses.';
 

--- a/renderer.php
+++ b/renderer.php
@@ -190,9 +190,9 @@ class block_coursefeedback_renderer extends plugin_renderer_base {
             'coursefeedbackid' => $feedbackid,
             'questionid' => $questionid
         ]);
-        $emptyans = $totalcount-$anscount;
+        $emptyans = $totalcount - $anscount;
         $answerhtml .= html_writer::tag('div',
-            get_string("qtype_empty_essayans","block_coursefeedback", $emptyans));
+            get_string("qtype_empty_essayans", "block_coursefeedback", $emptyans));
 
         // Add download link.
         $params = [

--- a/renderer.php
+++ b/renderer.php
@@ -206,21 +206,26 @@ class block_coursefeedback_renderer extends plugin_renderer_base {
         $answerhtml .= html_writer::tag('div', $link);
 
         // Get all non-empty textanswers for the given $questionid and add them in a table.
-        $sql = "SELECT id, textanswer 
-                  FROM {block_coursefeedback_textans}
-                 WHERE course = :course AND coursefeedbackid = :feedbackid AND questionid = :questionid 
-                       AND textanswer IS NOT NULL AND textanswer <> '' 
-                 LIMIT :perpage 
-                OFFSET :limitfrom";
-        $limitfrom = $perpage * $page;
+        $select = "course = :courseid
+               AND coursefeedbackid = :coursefeedbackid 
+               AND questionid = :questionid 
+               AND textanswer IS NOT NULL 
+               AND textanswer <> ''";
         $params = [
-            'course' => $courseid,
-            'feedbackid' => $feedbackid,
+            'courseid' => $courseid,
+            'coursefeedbackid' => $feedbackid,
             'questionid' => $questionid,
-            'perpage' => $perpage,
-            'limitfrom' => $limitfrom
         ];
-        $answers = $DB->get_records_sql($sql, $params);
+        $limitfrom = $perpage * $page;
+        $answers = $DB->get_records_select(
+            'block_coursefeedback_textans',
+            $select,
+            $params,
+            '',
+            'id, textanswer',
+            $limitfrom,
+            $perpage,
+        );
 
         // Get the $question(text) of the given $questionid
         $question = block_coursefeedback_get_questions_by_language($feedbackid, current_language(),

--- a/renderer.php
+++ b/renderer.php
@@ -146,7 +146,7 @@ class block_coursefeedback_renderer extends plugin_renderer_base {
             // Cell 2: "<questiontext>"
             $questiontext = format_string($essayquestion->question);
 
-            //Cell 3 "Show answers" (lnk).
+            // Cell 3 "Show answers" (lnk).
             $params = [
                 'course' => $courseid,
                 'feedback' => $essayquestion->coursefeedbackid,
@@ -171,20 +171,30 @@ class block_coursefeedback_renderer extends plugin_renderer_base {
      * @param array $essayquestions - array of question objects $essayquestions
      * @return string
      */
-    public function render_essay_answers($courseid, $feedbackid, $questionid, $totalcount, $page=0, $perpage=30) {
+    public function render_essay_answers($courseid, $feedbackid, $questionid, $anscount, $page=0, $perpage=30) {
         global $DB;
 
         // Start output with heading "Essay Feedbackresults"
         $answerhtml = html_writer::tag('h3',get_string("questiontype_essay", "block_coursefeedback")
             . ' ' . get_string("resultspage_title", "block_coursefeedback"));
 
-        // Add infos for $totalcount and current $page.
-        $totalpages = ceil($totalcount / $perpage);
+        // Add infos for $anscount and current $page.
+        $totalpages = ceil($anscount / $perpage);
         $answerhtml .= html_writer::tag('div',
                 get_string("page_html_totalanscountinfo", "block_coursefeedback",
-                    ['totalcount' => $totalcount, 'page' => $page + 1, 'totalpages' => $totalpages ]));
+                    ['anscount' => $anscount, 'page' => $page + 1, 'totalpages' => $totalpages ]));
 
-        // Add download
+        // Count total amount of textanswer DB entries (including empty). Calculate $emptyans and add it.
+        $totalcount = $DB->count_records('block_coursefeedback_textans', [
+            'course' => $courseid,
+            'coursefeedbackid' => $feedbackid,
+            'questionid' => $questionid
+        ]);
+        $emptyans = $totalcount-$anscount;
+        $answerhtml .= html_writer::tag('div',
+            get_string("qtype_empty_essayans","block_coursefeedback", $emptyans));
+
+        // Add download link.
         $params = [
             "course" => $courseid,
             "feedback" => $feedbackid,
@@ -195,18 +205,29 @@ class block_coursefeedback_renderer extends plugin_renderer_base {
             get_string("page_link_download", "block_coursefeedback", "CSV"));
         $answerhtml .= html_writer::tag('div', $link);
 
-        // Get all textanswers for the given $questionid and add them in a table.
+        // Get all non-empty textanswers for the given $questionid and add them in a table.
+        $sql = "SELECT id, textanswer 
+                  FROM {block_coursefeedback_textans}
+                 WHERE course = :course AND coursefeedbackid = :feedbackid AND questionid = :questionid 
+                       AND textanswer IS NOT NULL AND textanswer <> '' 
+                 LIMIT :perpage 
+                OFFSET :limitfrom";
         $limitfrom = $perpage * $page;
-        $answers = $DB->get_records('block_coursefeedback_textans', ['course' => $courseid,
-                'coursefeedbackid' => $feedbackid,
-                'questionid' => $questionid], '', 'id,textanswer', $limitfrom, $perpage);
+        $params = [
+            'course' => $courseid,
+            'feedbackid' => $feedbackid,
+            'questionid' => $questionid,
+            'perpage' => $perpage,
+            'limitfrom' => $limitfrom
+        ];
+        $answers = $DB->get_records_sql($sql, $params);
 
         // Get the $question(text) of the given $questionid
         $question = block_coursefeedback_get_questions_by_language($feedbackid, current_language(),
             CFB_QUESTIONTYPE_ESSAY, 'questionid', 'questionid,question', $questionid);
         $questiontext = format_string(reset($question)->question);
 
-        // Create and fill table .
+        // Create and fill table.
         $table = new html_table();
         $table->head = [get_string("notif_question", "block_coursefeedback").' '.$questionid.': ',
             $questiontext];
@@ -216,6 +237,7 @@ class block_coursefeedback_renderer extends plugin_renderer_base {
             $cell->colspan = 2;
             $table->data[] = new html_table_row([$cell]);
         }
+        // Add table with the non empty answers.
         $answerhtml .= html_writer::table($table);
 
         return $answerhtml;

--- a/version.php
+++ b/version.php
@@ -27,8 +27,8 @@
 
 defined("MOODLE_INTERNAL") || die();
 
-$plugin->version = 2024015002;
+$plugin->version = 2024020103;
 $plugin->requires = 2014051200;
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = "3.3.2 (Build: 2024015002)";
+$plugin->release = "3.3.3 (Build: 2024020103)";
 $plugin->component = "block_coursefeedback";

--- a/version.php
+++ b/version.php
@@ -27,8 +27,8 @@
 
 defined("MOODLE_INTERNAL") || die();
 
-$plugin->version = 2024020103;
+$plugin->version = 2024020600;
 $plugin->requires = 2014051200;
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = "3.3.3 (Build: 2024020103)";
+$plugin->release = "3.3.3 (Build: 2024020600)";
 $plugin->component = "block_coursefeedback";


### PR DESCRIPTION
Dieser PR verbessert die Darstellung der Freitextfragen-Antworten.
Leere Antworten werden nun gefiltert und nicht mehr in der Tabelle angezeigt.
Das Filtern passiert in den DB Abfragen selbst. Diese wurden dafür dementsprechend verändert.
Um den Lehrenden weiterhin die Info weiterzuleiten wieviele leere Antworten es gibt, wird dies über der Tabelle als kurze Info angezeigt.