### PR TITLE
Fix passing null error

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -559,7 +559,7 @@ function block_coursefeedback_get_qanswercounts($course, $feedbackid) {
             }
         }
         // Calculate choices and average for each question
-        $average = $choicessum > 0 ? ($avsum / $choicessum) : null;
+        $average = $choicessum > 0 ? ($avsum / $choicessum) : 0;
         $answers[$questionid]['average'] = number_format($average, 2);
         $answers[$questionid]['choicessum'] = $choicessum;
         $answers[$questionid]['abstentions'] = $abstentions;


### PR DESCRIPTION
Seid PHP 8 darf man der Funktion `number_format() `nicht mehr `null ` übergeben.

Es wird deshalb jetzt explizit 0 übergeben.