### PR TITLE
fix: Prevent error when adding 'infotext' column during upgrade

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -70,7 +70,7 @@ function xmldb_block_coursefeedback_upgrade($oldversion = 0) {
         // Add 'infotext' field to the 'block_coursefeedback' table
 
         $table = new xmldb_table('block_coursefeedback');
-        $field = new xmldb_field('infotext', XMLDB_TYPE_TEXT, null, null, null, null, null, 'heading');
+        $field = new xmldb_field('infotext', XMLDB_TYPE_TEXT, null, null, null, null, null);
 
         // Conditionally launch add field.
         if (!$dbman->field_exists($table, $field)) {

--- a/version.php
+++ b/version.php
@@ -27,8 +27,8 @@
 
 defined("MOODLE_INTERNAL") || die();
 
-$plugin->version = 2024020600;
+$plugin->version = 2025021900;
 $plugin->requires = 2014051200;
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = "3.3.3 (Build: 2024020600)";
+$plugin->release = "3.3.4 (Build: 2025021900)";
 $plugin->component = "block_coursefeedback";


### PR DESCRIPTION
Fixes issue #49

The previous parameter is unnecessary and can cause issues if the referenced column does not exist. PostgreSQL ignores it, and in MySQL/MariaDB, it may lead to upgrade failures. Removing it ensures compatibility across databases by always adding the column at the end of the table.
