### PR TITLE
Refactor the questionid ordering function

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -209,7 +209,7 @@ if (isset($form) && get_parent_class($form) === "coursefeedbackform" && $form->i
         case "questionsmove":
             if ($form->is_validated()) {
                 if (isset($data->position) && isset($data->template) && isset($data->questionid)) {
-                    if (block_coursefeedback_swap_questions($data->template, $data->questionid, $data->position)) {
+                    if (block_coursefeedback_move_question($data->template, $data->questionid, $data->position)) {
                         $statusmsg = get_string("changessaved");
                     } else {
                         $errormsg = get_string("therewereerrors", "admin");

--- a/lib.php
+++ b/lib.php
@@ -277,25 +277,19 @@ function block_coursefeedback_move_question(int $feedbackid, int $oldposition, i
                        SET questionid = questionid - (1 + :offset)
                      WHERE coursefeedbackid = :feedbackid
                            AND questionid BETWEEN (:oldposoffset + 1) AND :newposoffset";
-            $DB->execute($sql, [
-                'newposoffset' => $newposition + $offset,
-                'oldposoffset' => $oldposition + $offset,
-                'offset'       => $offset,
-                'feedbackid'   => $feedbackid,
-            ]);
         } elseif ($oldposition > $newposition) {
             // Moving to a lower position: shift intermediate questions one step up, considering the offset.
             $sql = "UPDATE {block_coursefeedback_questns}
                     SET questionid = questionid + (1 - :offset)
                     WHERE coursefeedbackid = :feedbackid
                       AND questionid BETWEEN :newposoffset AND (:oldposoffset - 1)";
-            $DB->execute($sql, [
-                'newposoffset' => $newposition + $offset,
-                'oldposoffset' => $oldposition + $offset,
-                'offset'       => $offset,
-                'feedbackid'   => $feedbackid,
-            ]);
         }
+        $DB->execute($sql, [
+            'newposoffset' => $newposition + $offset,
+            'oldposoffset' => $oldposition + $offset,
+            'offset'       => $offset,
+            'feedbackid'   => $feedbackid,
+        ]);
 
         // Step 3: Move the target question from its temporary offset position to the new position.
         $sql = "UPDATE {block_coursefeedback_questns}

--- a/lib.php
+++ b/lib.php
@@ -29,52 +29,43 @@ const COURSEFEEDBACK_DEFAULT = "DEFAULT";
 const COURSEFEEDBACK_ALL = "ALL";
 
 /**
- * Fixes holes in question id order.
+ * Fixes gaps in question id ordering for a given feedback.
  *
- * @param int $feedbackid
- * @param bool $checkonly don"t change database entries
- * @return 0 if operation failed or order is incorrect (checkonly), 1 if order is correct and 2 if order has succesful been changed
+ * @param int $feedbackid The feedback instance ID.
+ * @return bool true
+ * @throws dml_exception A DML specific exception is thrown for any errors.
  */
-function block_coursefeedback_order_questions($feedbackid, $checkonly = true) {
+function block_coursefeedback_order_questions(int $feedbackid): bool
+{
     global $DB;
+    // "mapping" generates a new consecutive ID (new_qid) for each distinct questionid by using 'row_number()'
+    // Then, the UPDATE statement joins the mapping with the target table to set:
+    // - questionid = new_qid | - timemodified = current timestamp (via time())
+    // for all rows belonging to the given feedback instance.
+    $sqlupdate = "WITH mapping AS (
+                      SELECT questionid, row_number() OVER (ORDER BY questionid) AS new_qid
+                        FROM (
+                            SELECT DISTINCT questionid
+                              FROM {block_coursefeedback_questns}
+                             WHERE coursefeedbackid = :feedbackid1
+                        ) sub
+                  )
+                  UPDATE {block_coursefeedback_questns} t
+                     SET questionid = mapping.new_qid, timemodified = :timemodified
+                    FROM mapping
+                   WHERE t.coursefeedbackid = :feedbackid2
+                         AND t.questionid = mapping.questionid";
 
-    $feedbackid = intval($feedbackid);
-    $max = block_coursefeedback_get_questioncount($feedbackid);
-    $currentid = 1;
-    $sql = array();
-    if ($max > 0) {
-        while ($currentid < $max) {
-            if (!$DB->record_exists("block_coursefeedback_questns",
-                    array("coursefeedbackid" => $feedbackid, "questionid" => $currentid))) {
-                while (!$DB->record_exists("block_coursefeedback_questns",
-                        array("coursefeedbackid" => $feedbackid, "questionid" => $max)) && $max > 0) {
-                    // Don"t use other spots.
-                    $max--;
-                }
-                $sql = array("query" => "UPDATE {block_coursefeedback_questns}
-                                            SET questionid = :currentid,timemodified = :modified
-                                          WHERE coursefeedbackid = :fid 
-                                                AND questionid = :max",
-                    "params" => array("currentid" => $currentid,
-                        "modified" => time(),
-                        "fid" => $feedbackid,
-                        "max" => $max));
-                $max--;
-            }
-            $currentid++;
-        }
-        if (empty($sql)) {
-            return 1;
-        } else if (!$checkonly) {
-            if (block_coursefeedback_execute_sql_arr($sql)) {
-                return 2;
-            } else {
-                return 0;
-            }
-        }
-    }
+    $params = [
+        'feedbackid1' => $feedbackid,
+        'feedbackid2' => $feedbackid,
+        'timemodified' => time()
+    ];
+
+    $result = $DB->execute($sqlupdate, $params);
+
+    return $result;
 }
-
 /**
  * If the function returns a negative number, it indicates a false validation (i.e. use of blacklisted characters).
  *
@@ -332,7 +323,7 @@ function block_coursefeedback_delete_question($feedbackid, $questionid, $languag
     $success = clean_param($success, PARAM_BOOL);
 
     if ($success) {
-        block_coursefeedback_order_questions($feedbackid, false);
+        block_coursefeedback_order_questions($feedbackid);
     }
 
     return $success;
@@ -782,40 +773,6 @@ function block_coursefeedback_create_activate_button($feedbackid, $value = "") {
     }
     $url = block_coursefeedback_adminurl("feedback", "activate", $feedbackid);
     return html_writer::link($url, $value);
-}
-
-/**
- * Reimplementation of the moodle 1.9 execute_sql_arr.
- *
- * Secrurity WARNING: All statements won't be validated, before they are executed!
- *
- * @param array $sqlarr Each field is one query, one query contains the query string (key "query") and his parameters (key "params")
- * @return boolean
- */
-function block_coursefeedback_execute_sql_arr($sqlarr) {
-    global $DB;
-
-    // Transaction handling; improves db consistancy.
-    $dbtrans = $DB->start_delegated_transaction();
-    $success = true;
-    foreach ($sqlarr as $sql) {
-        // Check if for null-pointer warnings before execution.
-        if (!isset($sql["query"]) || !isset($sql["params"])) {
-            continue;
-        }
-
-        if (!$DB->execute($sql["query"], $sql["params"])) {
-            $success = false;
-            break;
-        }
-    }
-    if ($success) {
-        $dbtrans->allow_commit();
-    } else {
-        $dbtrans->rollback(new dbtransfer_exception("dbupdatefailed"));
-    }
-
-    return $success;
 }
 
 /**

--- a/lib.php
+++ b/lib.php
@@ -35,15 +35,14 @@ const COURSEFEEDBACK_ALL = "ALL";
  * @return bool true
  * @throws dml_exception A DML specific exception is thrown for any errors.
  */
-function block_coursefeedback_order_questions(int $feedbackid): bool
-{
+function block_coursefeedback_order_questions(int $feedbackid): bool {
     global $DB;
-    // "mapping" generates a new consecutive ID (new_qid) for each distinct questionid by using 'row_number()'
+    // "mapping" generates a new consecutive ID (newquestionid) for each distinct questionid by using 'row_number()'
     // Then, the UPDATE statement joins the mapping with the target table to set:
-    // - questionid = new_qid | - timemodified = current timestamp (via time())
+    // - questionid = newquestionid
     // for all rows belonging to the given feedback instance.
     $sqlupdate = "WITH mapping AS (
-                      SELECT questionid, row_number() OVER (ORDER BY questionid) AS new_qid
+                      SELECT questionid, row_number() OVER (ORDER BY questionid) AS newquestionid
                         FROM (
                             SELECT DISTINCT questionid
                               FROM {block_coursefeedback_questns}
@@ -51,7 +50,7 @@ function block_coursefeedback_order_questions(int $feedbackid): bool
                         ) sub
                   )
                   UPDATE {block_coursefeedback_questns} t
-                     SET questionid = mapping.new_qid, timemodified = :timemodified
+                     SET questionid = mapping.newquestionid
                     FROM mapping
                    WHERE t.coursefeedbackid = :feedbackid2
                          AND t.questionid = mapping.questionid";
@@ -59,13 +58,13 @@ function block_coursefeedback_order_questions(int $feedbackid): bool
     $params = [
         'feedbackid1' => $feedbackid,
         'feedbackid2' => $feedbackid,
-        'timemodified' => time()
     ];
 
     $result = $DB->execute($sqlupdate, $params);
 
     return $result;
 }
+
 /**
  * If the function returns a negative number, it indicates a false validation (i.e. use of blacklisted characters).
  *
@@ -207,67 +206,91 @@ function block_coursefeedback_insert_question($question, $feedbackid, $questioni
 
     return false;
 }
-
 /**
- * @param int $feedbackid
- * @param int $oldpos
- * @param int $newpos
- * @return bool Success of operation
+ * Moves a question within the course feedback block to a new position.
+ *
+ * This function reorders questions by updating their questionid values.
+ * It uses a temporary offset to avoid unique constraint conflicts and performs
+ * the update in a transaction.
+ *
+ * @param int $feedbackid    The course feedback identifier.
+ * @param int $oldposition   The current position of the question.
+ * @param int $newposition   The target position for the question.
+ * @return bool            True if the operation was successful.
+ * @throws dml_exception   If a database error occurs.
  */
-function block_coursefeedback_swap_questions($feedbackid, $oldpos, $newpos) {
+function block_coursefeedback_move_question(int $feedbackid, int $oldposition, int $newposition): bool {
     global $DB;
 
-    $feedbackid = intval($feedbackid);
-    $oldpos = intval($oldpos);
-    $newpos = intval($newpos);
-    $tmppos = block_coursefeedback_get_questionid($feedbackid);
-
-    if ($DB->record_exists("block_coursefeedback_questns", array("coursefeedbackid" => $feedbackid, "questionid" => $oldpos))
-            && $DB->record_exists("block_coursefeedback_questns", array("coursefeedbackid" => $feedbackid, "questionid" => $newpos))) {
-        $sql = array();
-        // Set temporary position.
-        $sql[] = array(
-            "query" => "UPDATE {block_coursefeedback_questns}
-                           SET questionid = :tmppos
-                         WHERE coursefeedbackid = :feedbackid 
-                               AND questionid = :newpos",
-            "params" => array(
-                "tmppos" => $tmppos,
-                "feedbackid" => $feedbackid,
-                "newpos" => $newpos,
-            )
-        );
-        // Move to new position.
-        $sql[] = array(
-            "query" => "UPDATE {block_coursefeedback_questns}
-                           SET questionid = :newpos, timemodified = :modified
-                         WHERE coursefeedbackid = :fid 
-                               AND questionid = :oldpos",
-            "params" => array(
-                "newpos" => $newpos,
-                "modified" => time(),
-                "fid" => $feedbackid,
-                "oldpos" => $oldpos,
-            )
-        );
-        // Restore old position.
-        $sql[] = array(
-            "query" => "UPDATE {block_coursefeedback_questns}
-                           SET questionid = :oldpos, timemodified = :modified
-                         WHERE coursefeedbackid = :fid 
-                               AND questionid = :tmppos",
-            "params" => array(
-                "oldpos" => $oldpos,
-                "modified" => time(),
-                "fid" => $feedbackid,
-                "tmppos" => $tmppos,
-            )
-        );
-
-        return block_coursefeedback_execute_sql_arr($sql);
-    } else {
-        return false;
+    if ($oldposition === $newposition) {
+        return true;
     }
+
+    $transaction = $DB->start_delegated_transaction();
+
+    try {
+        // Get the current offset value.
+        $offset = block_coursefeedback_get_questionid($feedbackid);
+
+        // Step 1: Shift all affected questions to a temporary offset.
+        $sql = "UPDATE {block_coursefeedback_questns}
+                   SET questionid = questionid + :offset
+                 WHERE coursefeedbackid = :feedbackid
+                       AND questionid BETWEEN LEAST(:oldposition::bigint, :newposition::bigint)
+                                     AND GREATEST(:oldposition1::bigint, :newposition1::bigint)";
+        $DB->execute($sql, [
+            'offset'      => $offset,
+            'feedbackid'  => $feedbackid,
+            'oldposition' => $oldposition,
+            'newposition' => $newposition,
+            'oldposition1' => $oldposition,
+            'newposition1' => $newposition,
+        ]);
+
+        // Step 2: Adjust positions of intermediate questions.
+        if ($oldposition < $newposition) {
+            // Moving to a higher position: shift intermediate questions one step down, considering the offset.
+            $sql = "UPDATE {block_coursefeedback_questns}
+                       SET questionid = questionid - (1 + :offset)
+                     WHERE coursefeedbackid = :feedbackid
+                           AND questionid BETWEEN (:oldposoffset + 1) AND :newposoffset";
+            $DB->execute($sql, [
+                'newposoffset' => $newposition + $offset,
+                'oldposoffset' => $oldposition + $offset,
+                'offset'       => $offset,
+                'feedbackid'   => $feedbackid,
+            ]);
+        } elseif ($oldposition > $newposition) {
+            // Moving to a lower position: shift intermediate questions one step up, considering the offset.
+            $sql = "UPDATE {block_coursefeedback_questns}
+                    SET questionid = questionid + (1 - :offset)
+                    WHERE coursefeedbackid = :feedbackid
+                      AND questionid BETWEEN :newposoffset AND (:oldposoffset - 1)";
+            $DB->execute($sql, [
+                'newposoffset' => $newposition + $offset,
+                'oldposoffset' => $oldposition + $offset,
+                'offset'       => $offset,
+                'feedbackid'   => $feedbackid,
+            ]);
+        }
+
+        // Step 3: Move the target question from its temporary offset position to the new position.
+        $sql = "UPDATE {block_coursefeedback_questns}
+                   SET questionid = :newposition
+                 WHERE coursefeedbackid = :feedbackid
+                       AND questionid = :oldposoffset";
+        $DB->execute($sql, [
+            'oldposoffset' => $oldposition + $offset,
+            'newposition'  => $newposition,
+            'feedbackid'   => $feedbackid,
+        ]);
+    } catch (Exception $e) {
+        $transaction->rollback($e);
+        throw $e;
+    }
+    $transaction->allow_commit();
+
+    return true;
 }
 
 /**

--- a/lib.php
+++ b/lib.php
@@ -37,30 +37,53 @@ const COURSEFEEDBACK_ALL = "ALL";
  */
 function block_coursefeedback_order_questions(int $feedbackid): bool {
     global $DB;
-    // "mapping" generates a new consecutive ID (newquestionid) for each distinct questionid by using 'row_number()'
-    // Then, the UPDATE statement joins the mapping with the target table to set:
-    // - questionid = newquestionid
-    // for all rows belonging to the given feedback instance.
-    $sqlupdate = "WITH mapping AS (
-                      SELECT questionid, row_number() OVER (ORDER BY questionid) AS newquestionid
-                        FROM (
-                            SELECT DISTINCT questionid
-                              FROM {block_coursefeedback_questns}
-                             WHERE coursefeedbackid = :feedbackid1
-                        ) sub
-                  )
-                  UPDATE {block_coursefeedback_questns} t
-                     SET questionid = mapping.newquestionid
-                    FROM mapping
-                   WHERE t.coursefeedbackid = :feedbackid2
-                         AND t.questionid = mapping.questionid";
 
-    $params = [
-        'feedbackid1' => $feedbackid,
-        'feedbackid2' => $feedbackid,
-    ];
+    $transaction = $DB->start_delegated_transaction();
 
-    $result = $DB->execute($sqlupdate, $params);
+    try {
+        // Get the current offset value.
+        $offset = block_coursefeedback_get_questionid($feedbackid);
+
+        // Shift all affected questions to a temporary offset.
+        // We need this to make sure the (questionid, feedbackid, laguage) unique constraint is not violated
+        $sql = "UPDATE {block_coursefeedback_questns}
+                   SET questionid = questionid + :offset
+                 WHERE coursefeedbackid = :feedbackid";
+
+        $DB->execute($sql, [
+            'offset'      => $offset,
+            'feedbackid'  => $feedbackid
+        ]);
+
+        // "mapping" generates a new consecutive ID (newquestionid) for each distinct questionid by using 'row_number()'
+        // Then, the UPDATE statement joins the mapping with the target table to set:
+        // - questionid = newquestionid
+        // for all rows belonging to the given feedback instance.
+        $sqlupdate = "WITH mapping AS (
+                          SELECT questionid, row_number() OVER (ORDER BY questionid) AS newquestionid
+                            FROM (
+                                SELECT DISTINCT questionid
+                                  FROM {block_coursefeedback_questns}
+                                 WHERE coursefeedbackid = :feedbackid1
+                            ) sub
+                      )
+                      UPDATE {block_coursefeedback_questns} t
+                         SET questionid = mapping.newquestionid
+                        FROM mapping
+                       WHERE t.coursefeedbackid = :feedbackid2
+                             AND t.questionid = mapping.questionid";
+
+        $params = [
+            'feedbackid1' => $feedbackid,
+            'feedbackid2' => $feedbackid,
+        ];
+
+        $result = $DB->execute($sqlupdate, $params);
+    } catch (Exception $e) {
+        $transaction->rollback($e);
+        throw $e;
+    }
+    $transaction->allow_commit();
 
     return $result;
 }

--- a/lib.php
+++ b/lib.php
@@ -232,10 +232,6 @@ function block_coursefeedback_insert_question($question, $feedbackid, $questioni
 /**
  * Moves a question within the course feedback block to a new position.
  *
- * This function reorders questions by updating their questionid values.
- * It uses a temporary offset to avoid unique constraint conflicts and performs
- * the update in a transaction.
- *
  * @param int $feedbackid    The course feedback identifier.
  * @param int $oldposition   The current position of the question.
  * @param int $newposition   The target position for the question.
@@ -252,6 +248,10 @@ function block_coursefeedback_move_question(int $feedbackid, int $oldposition, i
     $transaction = $DB->start_delegated_transaction();
 
     try {
+        // Reordering questions by updating their questionid values.
+        // Making use of a temporary offset to avoid unique constraint conflicts and performing
+        // the update in a transaction.
+
         // Get the current offset value.
         $offset = block_coursefeedback_get_questionid($feedbackid);
 


### PR DESCRIPTION
Ordering the ids in one atomic sql querry now. It should increase the performance and it allows the deletion of `block_coursefeedback_execute_sql_arr()`

Checkonly mode was not used and was removed.

Since we only use the function when it is needed (when  questions are deleted), we don't need to check again for the need of ordering.

Also no use was made of the returns of the function. The return is now simplified to normal moodle standards.

Please note: This pull request is part of resolving https://github.com/eberhardt/moodle-block_coursefeedback/issues/47. All possible functions from lib.php will be moved to dedicated classes in a later step.

