### PR TITLE
PostgreSQL cast operator and phpdoc typos

### DIFF
--- a/exportlib.php
+++ b/exportlib.php
@@ -33,7 +33,7 @@ require_once(__DIR__ . "/locallib.php");
 /**
  * Export feedback data for a course.
  *
- * @package block
+ * @package block_coursefeedback
  * @copyright innoCampus, TU Berlin
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -84,7 +84,7 @@ class feedback_exporter {
 /**
  * Export essay answers for a given course.
  *
- * @package block
+ * @package block_coursefeedback
  * @copyright innoCampus, TU Berlin
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -157,7 +157,7 @@ class essay_exporter {
 /**
  * Export feedback data for an entire feedback.
  *
- * @package block
+ * @package block_coursefeedback
  * @copyright innoCampus, TU Berlin
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/lib.php
+++ b/lib.php
@@ -310,12 +310,17 @@ function block_coursefeedback_move_question(int $feedbackid, int $oldposition, i
 }
 
 /**
+ * Updates an existing question in a feedback.
+ *
+ * This function updates the text, type, and modification time of a question
+ * in the feedback if the specified language is supported.
+ *
  * @param int $feedbackid
  * @param int $questionid
- * @param string $question
- * @param string $language
- * @param bool $deleteanswers
- * @return bool Success of operation
+ * @param string $question The updated question text.
+ * @param string $language The language code of the question.
+ * @param int $questiontype The typeid of the question.
+ * @return bool True if the update was successful, false otherwise.
  */
 function block_coursefeedback_update_question($feedbackid, $questionid, $question, $language, $questiontype) {
     global $DB;

--- a/locallib.php
+++ b/locallib.php
@@ -124,7 +124,7 @@ function block_coursefeedback_get_courserankings(
     $sql = "
         SELECT course.courseid, cenrol.enroleduserssum, c.shortname, c.category, cc.path,  
                answer.one, answer.two, answer.three, answer.four, answer.five, answer.six, 
-               ROUND((answer.answersum::decimal / (NULLIF((course.answerstotal - abstentions), 0))), 3) as avfeedbackresult,
+               ROUND((CAST(answer.answersum as decimal(10,2)) / (NULLIF((course.answerstotal - abstentions), 0))), 3) as avfeedbackresult,
                (course.answerstotal - abstentions) as adjanswerstotal, answer.abstentions
     -- Initially get all courses with answers for the specific question and count the answers --
           FROM ( SELECT course as courseid, count(*) as answerstotal 

--- a/results.php
+++ b/results.php
@@ -17,7 +17,7 @@
 /**
  * Display answered feedbacks for a course.
  *
- * @package    block
+ * @package    block_coursefeedback
  * @copyright  2022 Felix Di Lenarda (@ innoCampus, TU Berlin)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */


### PR DESCRIPTION
A solution to fix #65, replacing '::' operator to cast() operator that works on postgresql and mariadb.
While comparing MOODLE_405_DEV with v3.3.5 as the officially last release of the plugin, I found missing phpdocs and typos, so I checked them.