### PR TITLE
Fix heading, language and deletion

### DIFF
--- a/classes/local/multilang_string.php
+++ b/classes/local/multilang_string.php
@@ -146,11 +146,11 @@ class multilang_string implements JsonSerializable {
             }
         }
 
+        // English.
+        yield 'en';
+
         // Site-wide default language.
         global $CFG;
         yield $CFG->lang;
-
-        // English.
-        yield 'en';
     }
 }

--- a/classes/local/surveyitem/surveyitem_manager.php
+++ b/classes/local/surveyitem/surveyitem_manager.php
@@ -153,7 +153,10 @@ class surveyitem_manager {
                 get_string('event_intro', 'block_coursefeedback', s($event->get('name')))
             );
         } else {
-            $heading = null;
+            $heading = html_writer::tag(
+                'h6',
+                get_string('event_intro_without_name', 'block_coursefeedback')
+            );
         }
 
         $advance_page = function () use (&$pages, &$current_page_items, $spe, $heading): void {

--- a/classes/local/table/evaluations_table.php
+++ b/classes/local/table/evaluations_table.php
@@ -108,7 +108,7 @@ class evaluations_table extends no_pagination_table {
             ])
         );
 
-        $this->candelete = has_capability('moodle/site:config', context_system::instance());
+        $this->candelete = has_capability('block/coursefeedback:manageorganizations', context_system::instance());
 
         $PAGE->requires->js_call_amd('block_coursefeedback/bulkactions_post', 'init');
     }

--- a/lang/de/block_coursefeedback.php
+++ b/lang/de/block_coursefeedback.php
@@ -119,6 +119,7 @@ $string['evaluation_settings'] = 'Evaluationseinstellungen';
 $string['evaluation_will_run_in_period'] = 'Die Umfrage wird im Zeitraum des {$a} laufen.';
 $string['evaluationadministration'] = 'Evaluationsverwaltung';
 $string['event_intro'] = 'Bewerten Sie bitte die Lehrveranstaltung <q><b>{$a}</b></q>.';
+$string['event_intro_without_name'] = 'Bitte bewerten Sie diese Lehrveranstaltung.';
 $string['event_name'] = 'Veranstaltungsname';
 $string['event_name_placeholder'] = 'Meine Lehrveranstaltung';
 $string['event_type'] = 'Veranstaltungsart';

--- a/lang/en/block_coursefeedback.php
+++ b/lang/en/block_coursefeedback.php
@@ -119,6 +119,7 @@ $string['evaluation_settings'] = 'Evaluation settings';
 $string['evaluation_will_run_in_period'] = 'The survey will run in the period of {$a}.';
 $string['evaluationadministration'] = 'Evaluation administration';
 $string['event_intro'] = 'Please rate the event <q><b>{$a}</b></q>.';
+$string['event_intro_without_name'] = 'Please rate this course.';
 $string['event_name'] = 'Event name';
 $string['event_name_placeholder'] = 'My teaching event';
 $string['event_type'] = 'Event type';

--- a/organization_evaluations.php
+++ b/organization_evaluations.php
@@ -50,7 +50,7 @@ if ($action) {
     require_sesskey();
     switch ($action) {
         case 'delete':
-            require_admin();
+            require_capability('block/coursefeedback:manageorganizations', $context);
             $courseids = required_param_array('selected', PARAM_INT);
 
             $coursecatids = organization_category::get_all_recursive_coursecatids($organization->get('id'));


### PR DESCRIPTION
- Display a fallback 'please rate this course' message above survey, even if there is no event name, to give some context.
- Try translating to english before site default
- Allow global eva admins to delete evaluations