### PR TITLE
Fix: Falscher Wert für N/A-Option

### DIFF
--- a/templates/surveyitems/scalequestion.mustache
+++ b/templates/surveyitems/scalequestion.mustache
@@ -86,7 +86,7 @@
             {{# has_na_option }}
                 <div class="d-flex text-md-center align-items-center justify-content-around coursefeedback-small-flex-basis-100 mt-2 mt-md-0" style="flex-basis: calc(100% / {{ optionamount }})">
                     <label class="block_coursefeedback-scaleoption mb-0">
-                        <input class="" type="radio" name="surveyitem-{{ surveyitemid }}" aria-label="{{{ na_option }}}" value="-1">
+                        <input class="" type="radio" name="surveyitem-{{ surveyitemid }}" aria-label="{{{ na_option }}}" value="0">
                         <span class="ms-1 d-md-none">{{{ na_option }}}</span>
                     </label>
                 </div>


### PR DESCRIPTION
Ich habe jetzt erstmal 0 gewinnen lassen (die richtigen Optionen fangen bei 1 an). Ob es -1 oder 0 ist, ist glaube ich ziemlich egal. I.g. -1 würde etwas eindeutiger machen, dass es ein besonderer Wert ist, aber :shrug: 