### PR TITLE
Fix: `overview.php` ohne `manageorganizations` anzeigen

### DIFF
--- a/lang/de/block_coursefeedback.php
+++ b/lang/de/block_coursefeedback.php
@@ -168,6 +168,7 @@ $string['no_answer_option_text'] = 'Text für die <abbr title="nicht zutreffend"
 $string['no_answers'] = 'Keine Antworten';
 $string['no_default_survey_period_set'] = 'Der Evaluationszeitraum ist noch nicht gesetzt. Er muss gesetzt werden, bevor Kurse zur Evaluation hinzugefügt werden können.';
 $string['no_edit_survey_period'] = 'Sie sind nicht berechtigt, den Evaluationszeitraum zu ändern.';
+$string['no_evaluation_permissions'] = 'Sie sind in keiner Organisationseinheit berechtigt, Evaluationen oder Fragebögen zu verwalten. Bitte wenden Sie sich an die Evaluationskoordinator/innen oder den Support.';
 $string['no_scale_selected'] = 'Bitten wählen Sie eine Skala';
 $string['no_survey_execution'] = 'Der Kurs {$a->fullname} ist nicht Teil einer vergangenen, laufenden oder zukünftigen Evaluation.';
 $string['not_enough_answers'] = 'Der Bericht kann nicht angezeigt werden, da es nicht genug Antworten gibt.';

--- a/lang/en/block_coursefeedback.php
+++ b/lang/en/block_coursefeedback.php
@@ -168,6 +168,7 @@ $string['no_answer_option_text'] = 'Text for the <abbr title="not applicable">n/
 $string['no_answers'] = 'No answers';
 $string['no_default_survey_period_set'] = 'No default evaluation period set. Please define an evaluation period before creating surveys.';
 $string['no_edit_survey_period'] = 'You are not allowed to edit the survey period.';
+$string['no_evaluation_permissions'] = 'You do not have permission to manage survey settings or questionnaires in any organisation. Please contact your evaluation coordinators or the support.';
 $string['no_scale_selected'] = 'Please select a scale';
 $string['no_survey_execution'] = 'The course {$a->fullname} is not part of any past, current or future survey.';
 $string['not_enough_answers'] = 'The report cannot be shown, because there are not enough answers.';

--- a/overview.php
+++ b/overview.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Show details for an organization.
+ * Show links to the organization and/or questionnaire lists, depending on what the user has access to.
  *
  * @package    block_coursefeedback
  * @copyright  2025 innoCampus, Technische Universität Berlin
@@ -24,16 +24,18 @@
  */
 
 use block_coursefeedback\local\manager\permission_manager;
+use block_coursefeedback\local\manager\user_organization_cache_manager;
+use core\exception\moodle_exception;
 
 require_once(__DIR__ . '/../../config.php');
 global $CFG, $OUTPUT, $PAGE;
 
 require_login();
 if (!permission_manager::can_do_any_evaluation_administration()) {
-    throw new \core\exception\coding_exception('You are not permitted to do that.');
+    throw new moodle_exception('no_evaluation_permissions', 'block_coursefeedback');
 }
+
 $context = context_system::instance();
-require_capability('block/coursefeedback:manageorganizations', $context);
 
 $PAGE->set_url(new moodle_url('/blocks/coursefeedback/overview.php'));
 $PAGE->set_context($context);
@@ -43,7 +45,10 @@ $PAGE->set_title($title);
 
 echo $OUTPUT->header();
 
-if (has_capability('block/coursefeedback:manageorganizations', $context)) {
+if (
+    has_capability('block/coursefeedback:manageorganizations', $context)
+    || user_organization_cache_manager::get_instance()->is_user_evaluation_coordinator_anywhere()
+) {
     echo \core\output\html_writer::link(
         new moodle_url('/blocks/coursefeedback/organizations.php'),
         get_string('organizations', 'block_coursefeedback'),


### PR DESCRIPTION
Für EBs, die zu einer Org gehören und mit Fragebögen spielen dürfen, aber Orgs nicht verwalten können, hat die Seite geworfen, weil ein `require_capability` drin war.