### PR TITLE
LV-Tabelle und Anleitung unter bestimmten Bedingungen verstecken

### DIFF
--- a/course.php
+++ b/course.php
@@ -118,7 +118,7 @@ $PAGE->set_title(get_string('course_settings_of', 'block_coursefeedback', $cours
 echo $OUTPUT->header();
 echo $OUTPUT->heading(get_string('course_settings', 'block_coursefeedback'));
 
-$show_event_table = count($model->events_by_id) > 0 || permission_manager::can_edit_course_surveysettings($course, $organization);
+$show_event_table = permission_manager::can_edit_course_surveysettings($course, $organization);
 global $DB;
 $num_responses = $DB->count_records(
     'block_coursefeedback_surveyexecution_user',


### PR DESCRIPTION
Versteckt die LV-Tabelle für Nutzer:innen, die diese eh nie bearbeiten konnten (d.h. basierend auf `can_edit_course_surveysettings`, nicht auf `is_se_frozen`.)

~~Versteckt außerdem die Anleitung zu der LV-Tabelle für Nutzer:innen, die sie grundsätzlich bearbeiten können, aber aufgrund der Frozenheit nur noch geringfügig.~~