### PR TITLE
Randomize IDs for user survey participation records

### DIFF
--- a/classes/external/save_survey_answers.php
+++ b/classes/external/save_survey_answers.php
@@ -19,9 +19,7 @@ namespace block_coursefeedback\external;
 use block_coursefeedback\local\survey_execution_data;
 use block_coursefeedback\local\surveyitem\surveyitem_manager;
 use block_coursefeedback\local\surveyitemtype_answerdata;
-use core\clock;
 use core\context\course;
-use core\di;
 use core\exception\coding_exception;
 use core_external\external_api;
 use core_external\external_function_parameters;
@@ -167,12 +165,41 @@ class save_survey_answers extends external_api {
         }
 
         // Save the fact that the user completed this survey execution.
-        $DB->insert_record('block_coursefeedback_surveyexecution_user', [
-            'surveyexecutionid' => $course_data->survey_execution->get('id'),
-            'userid' => $USER->id,
-        ]);
+        $maxtries = 10;
+        $successful = false;
+        for ($i = 0; $i < $maxtries; $i++) {
+            try {
+                $DB->insert_record_raw('block_coursefeedback_surveyexecution_user', [
+                    'id' => random_int(0x1, 0xffffffff),
+                    'surveyexecutionid' => $course_data->survey_execution->get('id'),
+                    'userid' => $USER->id,
+                ], customsequence: true);
+                $successful = true;
+                break;
+            } catch (\dml_exception $exception) {
+                continue;
+            }
+        }
+        if (!$successful) {
+            throw new moodle_exception('could_not_save_participation', 'block_coursefeedback');
+        }
 
         $transaction->allow_commit();
+
+        $userids = $DB->get_fieldset(
+            'block_coursefeedback_surveyexecution_user',
+            'userid',
+            ['surveyexecutionid' => $course_data->survey_execution->get('id')]
+        );
+        if (count($userids) > 1) {
+            $selected = $userids[random_int(0, count($userids) - 1)];
+            $DB->execute('UPDATE {block_coursefeedback_surveyexecution_user} ' .
+                'SET userid=:userid1 WHERE userid=:userid2 AND surveyexecutionid=:seid', [
+                'userid1' => $selected,
+                'userid2' => $selected,
+                'seid' => $course_data->survey_execution->get('id'),
+            ]);
+        }
 
         return [];
     }

--- a/lang/de/block_coursefeedback.php
+++ b/lang/de/block_coursefeedback.php
@@ -46,6 +46,7 @@ $string['cannot_manually_add'] = 'Fragebogen-Elemente des Typs \'{$a}\' können 
 $string['center_option_text'] = 'Beschriftung der mittleren Option';
 $string['confirm_event_deletion'] = 'Möchten Sie wirklich die Lehrveranstaltung <q><b>{$a}</b></q> aus der Evaluation löschen?';
 $string['confirm_slot_deletion'] = 'Möchten Sie wirklich die Untergruppe <q><b>{$a}</b></q> aus der Evaluation löschen?';
+$string['could_not_save_participation'] = 'Teilnahme konnte nicht gespeichert werden.';
 $string['course_event_slot_table_heading'] = 'Lehrveranstaltungen und Untergruppen';
 $string['course_not_in_org'] = 'Der Kurs \'{$a->course_name}\' gehört nicht zu Organisationseinheit \'{$a->org_name}\'.';
 $string['course_settings'] = 'Evaluationseinstellungen';

--- a/lang/en/block_coursefeedback.php
+++ b/lang/en/block_coursefeedback.php
@@ -46,6 +46,7 @@ $string['cannot_manually_add'] = 'Questionnaire elements of type \'{$a}\' cannot
 $string['center_option_text'] = 'Text for the center option';
 $string['confirm_event_deletion'] = 'Are you sure you want to delete the teaching event <q><b>{$a}</b></q>?';
 $string['confirm_slot_deletion'] = 'Are you sure you want to delete the slot <q><b>{$a}</b></q>?';
+$string['could_not_save_participation'] = 'Could not save participation.';
 $string['course_event_slot_table_heading'] = 'Teaching Events and Response Slots';
 $string['course_not_in_org'] = 'The course \'{$a->course_name}\' does not belong to organization \'{$a->org_name}\'.';
 $string['course_settings'] = 'Survey settings';


### PR DESCRIPTION
- Use a random ID
- Update a random record afterwards to randomize the implicit ordering